### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/DeploymentCenter/api/api.py
+++ b/DeploymentCenter/api/api.py
@@ -14,6 +14,7 @@
    limitations under the License.
 '''
 import os
+import logging
 from flask import Flask, request, jsonify
 from database import User as us
 from database import Chatroom as ch
@@ -21,6 +22,7 @@ from database import Database as db
 from datetime import datetime
 from crypting import Crypting as cr
 app = Flask(__name__)
+app.logger.setLevel(logging.ERROR)
 
 with open(os.path.join(os.path.dirname(__file__), "..", "..", 'conf', 'api.conf'), 'r') as f:
     api_conf = f.read().splitlines()
@@ -101,7 +103,8 @@ def send_message():
         })
         return jsonify({'success': 'Message sent'}), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error('Exception occurred', exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 500
 
 @app.route('/delete_message', methods=['POST'])
 def delete_message():


### PR DESCRIPTION
Potential fix for [https://github.com/AIIrondev/Chatsystem/security/code-scanning/1](https://github.com/AIIrondev/Chatsystem/security/code-scanning/1)

To fix the problem, we should avoid returning the raw exception message to the user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

1. Modify the exception handling in the `send_message` function to log the exception and return a generic error message.
2. Add an import for the `logging` module to handle logging the exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
